### PR TITLE
Update blocknote deps

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -8,9 +8,9 @@
       "name": "uses-component",
       "version": "0.0.0",
       "dependencies": {
-        "@blocknote/core": "^0.31.0",
-        "@blocknote/mantine": "^0.31.0",
-        "@blocknote/react": "^0.31.0",
+        "@blocknote/core": "0.32.0-hackdays.0",
+        "@blocknote/mantine": "0.32.0-hackdays.0",
+        "@blocknote/react": "0.32.0-hackdays.0",
         "@convex-dev/prosemirror-sync": "file:..",
         "@mantine/core": "^7.5.3",
         "@tiptap/core": "^2.11.7",
@@ -49,7 +49,7 @@
       "version": "0.1.19",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@blocknote/core": "0.31.1",
+        "@blocknote/core": "0.32.0-hackdays.0",
         "@eslint/js": "9.28.0",
         "@types/node": "18.19.110",
         "@types/react": "19.1.6",
@@ -62,10 +62,10 @@
         "vitest": "3.2.0"
       },
       "optionalDependencies": {
-        "@blocknote/core": "^0.29.1 || ^0.30.0 || ^0.31.0"
+        "@blocknote/core": "^0.29.1 || ^0.30.0 || ^0.31.0 || ^0.32.0-hackdays.0"
       },
       "peerDependencies": {
-        "@blocknote/core": "^0.29.1 || ^0.30.0 || ^0.31.0",
+        "@blocknote/core": "^0.29.1 || ^0.30.0 || ^0.31.0 || ^0.32.0-hackdays.0",
         "@tiptap/core": "^2.7.0",
         "convex": ">=1.21.0 <1.35.0",
         "react": "^18.3.1 || ^19.0.0",
@@ -393,9 +393,9 @@
       }
     },
     "node_modules/@blocknote/core": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@blocknote/core/-/core-0.31.1.tgz",
-      "integrity": "sha512-EGRYksdz1MxgqlmLzvhjWZvwL2Q8iiWY8tbXTBcYSEMyEdxWM5t4v2lcfTuuZuz8wInMR/c7MW8ymlzoYxrBZA==",
+      "version": "0.32.0-hackdays.0",
+      "resolved": "https://registry.npmjs.org/@blocknote/core/-/core-0.32.0-hackdays.0.tgz",
+      "integrity": "sha512-yRfAyNYJRp1QGuG51Fh2XQ6CeQTr1qn6DgJTyPtdqZEQ4h5TgYseFb6nmRUHYN0HK0X9in7uIPQedB79KnZy7A==",
       "license": "MPL-2.0",
       "dependencies": {
         "@emoji-mart/data": "^1.2.1",
@@ -448,13 +448,13 @@
       }
     },
     "node_modules/@blocknote/mantine": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@blocknote/mantine/-/mantine-0.31.1.tgz",
-      "integrity": "sha512-0s46A3wpRY0/XXxf0j824BbDzt3JSZe4g7J9kNXB5wUngFp1Oo4spMEZ7zAi/IkrkMXFz67SaLIX6NpDBHSG9Q==",
+      "version": "0.32.0-hackdays.0",
+      "resolved": "https://registry.npmjs.org/@blocknote/mantine/-/mantine-0.32.0-hackdays.0.tgz",
+      "integrity": "sha512-FiJKfkANl0/4gEQ735Rw8NSFG39hBpVfMw+fQ9M2AMJGrhDKaAQ2dM9C9q2wSFx2oqvhJB/8x3HhoJMD91cX5A==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@blocknote/core": "0.31.1",
-        "@blocknote/react": "0.31.1",
+        "@blocknote/core": "0.32.0-hackdays.0",
+        "@blocknote/react": "0.32.0-hackdays.0",
         "@mantine/core": "^7.10.1",
         "@mantine/hooks": "^7.10.1",
         "@mantine/utils": "^6.0.21",
@@ -466,12 +466,12 @@
       }
     },
     "node_modules/@blocknote/react": {
-      "version": "0.31.1",
-      "resolved": "https://registry.npmjs.org/@blocknote/react/-/react-0.31.1.tgz",
-      "integrity": "sha512-S7Edl+eQjRf+2/iBHayjzOGSyjPDz4hsMbnLL8H+tl5XbE93u6KrBKkYEqU+yij6uKMounftrpxzdBY2UFgyiQ==",
+      "version": "0.32.0-hackdays.0",
+      "resolved": "https://registry.npmjs.org/@blocknote/react/-/react-0.32.0-hackdays.0.tgz",
+      "integrity": "sha512-0V7LtDB91vmLAkYNYLQx8f7cMjIJrAbv0N7IoLk9Fx37ehjq3prFhbDL7g7YYF2a1LxGqGYuGuNqRYcTO5LTZg==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@blocknote/core": "0.31.1",
+        "@blocknote/core": "0.32.0-hackdays.0",
         "@emoji-mart/data": "^1.2.1",
         "@floating-ui/react": "^0.26.4",
         "@tiptap/core": "^2.12.0",
@@ -5234,6 +5234,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
       "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
       "peerDependencies": {
         "react": "*"
       }

--- a/example/package.json
+++ b/example/package.json
@@ -11,9 +11,9 @@
     "lint": "tsc -p convex && eslint convex && npx tsc --noEmit"
   },
   "dependencies": {
-    "@blocknote/core": "^0.31.0",
-    "@blocknote/mantine": "^0.31.0",
-    "@blocknote/react": "^0.31.0",
+    "@blocknote/core": "0.32.0-hackdays.0",
+    "@blocknote/mantine": "0.32.0-hackdays.0",
+    "@blocknote/react": "0.32.0-hackdays.0",
     "@convex-dev/prosemirror-sync": "file:..",
     "@mantine/core": "^7.5.3",
     "@tiptap/core": "^2.11.7",

--- a/package.json
+++ b/package.json
@@ -83,17 +83,17 @@
     }
   },
   "peerDependencies": {
-    "@blocknote/core": "^0.29.1 || ^0.30.0 || ^0.31.0",
+    "@blocknote/core": "^0.29.1 || ^0.30.0 || ^0.31.0 || ^0.32.0-hackdays.0",
     "@tiptap/core": "^2.7.0",
     "convex": ">=1.21.0 <1.35.0",
     "react": "^18.3.1 || ^19.0.0",
     "react-dom": "^18.3.1 || ^19.0.0"
   },
   "optionalDependencies": {
-    "@blocknote/core": "^0.29.1 || ^0.30.0 || ^0.31.0"
+    "@blocknote/core": "^0.29.1 || ^0.30.0 || ^0.31.0 || ^0.32.0-hackdays.0"
   },
   "devDependencies": {
-    "@blocknote/core": "0.31.1",
+    "@blocknote/core": "0.32.0-hackdays.0",
     "@eslint/js": "9.28.0",
     "@types/node": "18.19.110",
     "@types/react": "19.1.6",


### PR DESCRIPTION
Chef is struggling because types in the latest version don't match the component's types.