### PR TITLE
Redefine vClientId in client file to avoid schema import issue

### DIFF
--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -10,9 +10,10 @@ import {
 } from "convex/server";
 import { v, VString } from "convex/values";
 import { Mounts } from "../component/_generated/api";
-import { vClientId } from "../component/schema";
 import { Schema, Node } from "@tiptap/pm/model";
 import { Step, Transform } from "@tiptap/pm/transform";
+
+const vClientId = v.union(v.string(), v.number());
 
 export type SyncApi = ApiFromModules<{
   sync: ReturnType<ProsemirrorSync["syncApi"]>;


### PR DESCRIPTION
## Description:
This PR removes the vClientId import from the schema and redeclares it directly in the client file.
When running tests with convex-test, the client and schema modules are loaded separately, causing import errors if the client depends on the schema.
This change ensures the client can be used independently without schema coupling.
