### PR TITLE
use convex linter

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,6 +3,7 @@ import pluginJs from "@eslint/js";
 import tseslint from "typescript-eslint";
 import reactHooks from "eslint-plugin-react-hooks";
 import reactRefresh from "eslint-plugin-react-refresh";
+import convexPlugin from "@convex-dev/eslint-plugin";
 
 export default [
   {
@@ -37,7 +38,12 @@ export default [
     languageOptions: {
       globals: globals.worker,
     },
+    plugins: {
+      "@convex-dev": convexPlugin,
+    },
     rules: {
+      ...convexPlugin.configs.recommended[0].rules,
+
       "@typescript-eslint/no-floating-promises": "error",
       "@typescript-eslint/no-explicit-any": "off",
       "no-unused-vars": "off",

--- a/example/convex/example.ts
+++ b/example/convex/example.ts
@@ -67,7 +67,7 @@ export const updateDocSearchIndex = internalMutation({
     if (!existing) {
       await ctx.db.insert("documents", { docId: id, content });
     } else {
-      await ctx.db.patch(existing._id, { content });
+      await ctx.db.patch("documents", existing._id, { content });
     }
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@blocknote/core": "0.49.0",
         "@blocknote/mantine": "0.49.0",
         "@blocknote/react": "0.49.0",
+        "@convex-dev/eslint-plugin": "^2.0.0",
         "@edge-runtime/vm": "5.0.0",
         "@eslint/eslintrc": "3.3.5",
         "@eslint/js": "10.0.1",
@@ -421,6 +422,20 @@
       "integrity": "sha512-5dyB8nLC/qogMrlCizZnYWQTA4lnb/v+It+sqNl5YnSRAPMlIqY/X0Xn+gZw8vOL+TgTTr28VEbn3uf8fUtAkw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@convex-dev/eslint-plugin": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@convex-dev/eslint-plugin/-/eslint-plugin-2.0.0.tgz",
+      "integrity": "sha512-GxYe0b5RoAb7c7JzcAX3t+UrdT6edQDtSgJ2F9UPECLyQGU0TeTkyGsDXNm3HK+MnWYi8isRlqaqoYTUD0Ko+Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@typescript-eslint/types": "~8.58.0",
+        "@typescript-eslint/utils": "~8.58.0"
+      },
+      "peerDependencies": {
+        "convex": "^1.34.1"
+      }
     },
     "node_modules/@edge-runtime/primitives": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "@blocknote/core": "0.49.0",
     "@blocknote/mantine": "0.49.0",
     "@blocknote/react": "0.49.0",
+    "@convex-dev/eslint-plugin": "^2.0.0",
     "@edge-runtime/vm": "5.0.0",
     "@eslint/eslintrc": "3.3.5",
     "@eslint/js": "10.0.1",

--- a/src/component/lib.ts
+++ b/src/component/lib.ts
@@ -265,7 +265,7 @@ async function deleteSnapshotsHelper(
       return before;
     })
     .take(MAX_SNAPSHOT_FETCH);
-  await Promise.all(versions.map((doc) => ctx.db.delete(doc._id)));
+  await Promise.all(versions.map((doc) => ctx.db.delete("snapshots", doc._id)));
   if (versions.length === MAX_SNAPSHOT_FETCH) {
     await ctx.scheduler.runAfter(0, api.lib.deleteSnapshots, {
       id: args.id,
@@ -308,7 +308,7 @@ export const deleteSteps = mutation({
         )
         .take(MAX_DELTA_FETCH)
     ).filter((doc) => doc._creationTime < beforeTs);
-    await Promise.all(deltas.map((doc) => ctx.db.delete(doc._id)));
+    await Promise.all(deltas.map((doc) => ctx.db.delete("deltas", doc._id)));
     if (deltas.length === MAX_DELTA_FETCH) {
       await ctx.scheduler.runAfter(0, api.lib.deleteSteps, {
         id: args.id,


### PR DESCRIPTION
## Summary
- Install and configure `@convex-dev/eslint-plugin` 
- Auto-fix `explicit-table-ids` violations (adds table name as first arg to `db.get`/`db.patch`/`db.delete`/`db.replace`)
- Add eslint-disable annotations where table names are genuinely dynamic

🤖 Generated with [Claude Code](https://claude.com/claude-code)