### PR TITLE
fix(tiptap): three lifecycle bugs — StrictMode subscription teardown, post-await version re-check, flush pending steps on destroy

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,44 @@ const sync = useTiptapSync(api.example, "some-id", {
 });
 ```
 
+### Handling sync errors
+
+Pass `onSyncError` to be told when syncing fails:
+
+```ts
+const sync = useTiptapSync(api.example, "some-id", {
+  onSyncError: (error) => {
+    console.error("Sync failed", error);
+  },
+});
+```
+
+It's strongly recommended. Most sync work happens in the background, with no
+caller to propagate a failure to:
+
+- The debounced snapshot submit.
+- The flush of unconfirmed steps when the editor is destroyed (see below).
+
+Without a handler, those failures surface as unhandled promise rejections
+instead.
+
+Errors are generally informational — the extension keeps syncing, and retries on
+the next local change or update from the server. The one error that means data
+was lost is `"Unsynced steps could not be flushed after destroy"`: local steps
+that never made it to the server before the editor went away.
+
+### Unmounting with unsynced changes
+
+Local steps are the source of truth until the server confirms them, so when an
+editor is destroyed with steps still in flight — the user switches documents in
+your app mid-round-trip, for instance — the extension submits them in the
+background rather than dropping them. `warnOnUnsyncedClose` only covers closing
+the tab, which the browser lets us block; an in-app unmount can't be blocked.
+
+The flush is best-effort: if the request fails (offline, say), the steps are
+lost and `onSyncError` is called. To avoid the situation entirely, keep the
+editor mounted until `collab.sendableSteps(editor.state)` returns null.
+
 ### Creating a new document
 
 You can create a new document from the client by calling `sync.create(content)`,

--- a/src/component/lib.test.ts
+++ b/src/component/lib.test.ts
@@ -241,6 +241,34 @@ describe("prosemirror lib", () => {
       }),
     ).rejects.toThrow();
   });
+  test("a gap in the delta log makes getSteps fail permanently", async () => {
+    // The invariant clients must not break: submitSteps doesn't check that the
+    // submitted version is the server's head, so a client whose local version
+    // has drifted ahead writes a delta with a gap — after which no client can
+    // catch up. This is why the tiptap extension re-checks its collab version
+    // after awaiting getSteps before applying them.
+    const t = convexTest(schema, modules);
+    const id = crypto.randomUUID();
+    await t.run(async (ctx) => {
+      await ctx.db.insert("snapshots", { id, version: 1, content: "content" });
+      await ctx.db.insert("deltas", {
+        id,
+        version: 2,
+        clientId: "client1",
+        steps: ["a"],
+      });
+      // Versions 3 and 4 were never recorded: this client believed it was at 4.
+      await ctx.db.insert("deltas", {
+        id,
+        version: 5,
+        clientId: "client2",
+        steps: ["d"],
+      });
+    });
+    await expect(t.query(api.lib.getSteps, { id, version: 2 })).rejects.toThrow(
+      "Missing steps 3...4",
+    );
+  });
   test("submitSnapshot deletes older snapshot", async () => {
     const t = convexTest(schema, modules);
     const id = crypto.randomUUID();

--- a/src/tiptap/index.test.ts
+++ b/src/tiptap/index.test.ts
@@ -1,0 +1,369 @@
+/// <reference types="vite/client" />
+
+import { webcrypto as crypto } from "node:crypto";
+import { describe, expect, test, vi } from "vitest";
+import { convexTest, type TestConvex } from "convex-test";
+import type { ConvexReactClient } from "convex/react";
+import type { AnyExtension, Editor } from "@tiptap/core";
+import { Schema } from "@tiptap/pm/model";
+import { EditorState } from "@tiptap/pm/state";
+import * as collab from "prosemirror-collab";
+import componentSchema from "../component/schema.js";
+import { api } from "../component/_generated/api.js";
+import type { SyncApi } from "../client/index.js";
+import { flushPendingSteps, syncExtension } from "./index.js";
+
+const modules = import.meta.glob("../component/**/*.*s");
+
+// The component's function references are shaped the same as the ones the
+// client generates via `prosemirrorSync.syncApi()`.
+const syncApi = api.lib as unknown as SyncApi;
+
+type SubmitStepsArgs = {
+  id: string;
+  version: number;
+  clientId: string | number;
+  steps: string[];
+};
+type SubmitStepsResult =
+  | { status: "synced" }
+  | {
+      status: "needs-rebase";
+      steps: string[];
+      clientIds: (string | number)[];
+    };
+
+/**
+ * A `ConvexReactClient` stand-in exposing just what `flushPendingSteps` uses:
+ * `mutation(syncApi.submitSteps, args)`. The function reference is ignored
+ * since that's the only call it makes.
+ */
+function fakeClient(
+  submitSteps: (args: SubmitStepsArgs) => Promise<SubmitStepsResult>,
+): ConvexReactClient {
+  return {
+    mutation: (_reference: unknown, args: unknown) =>
+      submitSteps(args as SubmitStepsArgs),
+  } as unknown as ConvexReactClient;
+}
+
+function realClient(t: TestConvex<typeof componentSchema>): ConvexReactClient {
+  return fakeClient((args) => t.mutation(api.lib.submitSteps, args));
+}
+
+// A minimal schema: enough to make real ProseMirror steps that apply cleanly.
+const schema = new Schema({
+  nodes: {
+    doc: { content: "paragraph+" },
+    paragraph: { content: "text*", toDOM: () => ["p", 0] },
+    text: {},
+  },
+});
+
+/** An editor state with the collab plugin at `version`, as the extension sets up. */
+function stateAt(version: number, clientID: string) {
+  return EditorState.create({
+    schema,
+    plugins: [collab.collab({ version, clientID })],
+  });
+}
+
+/** Produce an unconfirmed local step, the way typing in the editor would. */
+function typeText(state: EditorState, text: string) {
+  return state.apply(state.tr.insertText(text, 1));
+}
+
+function stepsJSON(state: EditorState) {
+  return collab
+    .sendableSteps(state)!
+    .steps.map((step) => JSON.stringify(step.toJSON()));
+}
+
+async function seedSnapshot(
+  t: TestConvex<typeof componentSchema>,
+  id: string,
+  version = 1,
+) {
+  await t.run(async (ctx) => {
+    await ctx.db.insert("snapshots", { id, version, content: "{}" });
+  });
+}
+
+describe("flushPendingSteps", () => {
+  test("submits unconfirmed steps left over when the editor is destroyed", async () => {
+    const t = convexTest(componentSchema, modules);
+    const id = crypto.randomUUID();
+    await seedSnapshot(t, id);
+    const state = typeText(stateAt(1, "me"), "hello");
+    expect(collab.sendableSteps(state)).not.toBeNull();
+
+    expect(await flushPendingSteps(realClient(t), syncApi, id, state)).toBe(
+      "flushed",
+    );
+
+    // The step the destroyed view was still holding is now on the server.
+    const server = await t.query(api.lib.getSteps, { id, version: 1 });
+    expect(server.version).toBe(2);
+    expect(server.clientIds).toEqual(["me"]);
+  });
+
+  test("rebases over steps that landed first, then submits", async () => {
+    const t = convexTest(componentSchema, modules);
+    const id = crypto.randomUUID();
+    // Another client's edit reached the server while we were unmounting.
+    const foreignSteps = stepsJSON(typeText(stateAt(1, "other"), "abc"));
+    await seedSnapshot(t, id);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("deltas", {
+        id,
+        version: 2,
+        clientId: "other",
+        steps: foreignSteps,
+      });
+    });
+    const state = typeText(stateAt(1, "me"), "XYZ");
+
+    expect(await flushPendingSteps(realClient(t), syncApi, id, state)).toBe(
+      "flushed",
+    );
+
+    const server = await t.query(api.lib.getSteps, { id, version: 1 });
+    expect(server.version).toBe(3);
+    expect(server.clientIds).toEqual(["other", "me"]);
+  });
+
+  test("confirms — without duplicating — steps whose in-flight submit landed", async () => {
+    const t = convexTest(componentSchema, modules);
+    const id = crypto.randomUUID();
+    const state = typeText(stateAt(1, "me"), "hello");
+    // The submitSteps that was in flight when the editor was destroyed did
+    // land; the view just never got to apply the confirmation.
+    const ownSteps = stepsJSON(state);
+    await seedSnapshot(t, id);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("deltas", {
+        id,
+        version: 2,
+        clientId: "me",
+        steps: ownSteps,
+      });
+    });
+
+    expect(await flushPendingSteps(realClient(t), syncApi, id, state)).toBe(
+      "flushed",
+    );
+
+    // Still one delta: the steps were recognized as ours and confirmed, not
+    // written a second time.
+    const server = await t.query(api.lib.getSteps, { id, version: 1 });
+    expect(server.version).toBe(2);
+    expect(server.steps).toEqual(ownSteps);
+  });
+
+  test("confirms own landed steps and absorbs foreign ones after them", async () => {
+    const t = convexTest(componentSchema, modules);
+    const id = crypto.randomUUID();
+    const state = typeText(stateAt(1, "me"), "mine");
+    const ownSteps = stepsJSON(state);
+    // Our in-flight submit landed at v2, then another client edited on top of
+    // it, so the needs-rebase response is ours-then-theirs.
+    const foreign = typeText(
+      EditorState.create({
+        doc: state.doc,
+        plugins: [collab.collab({ version: 2, clientID: "other" })],
+      }),
+      "THEIRS",
+    );
+    await seedSnapshot(t, id);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("deltas", {
+        id,
+        version: 2,
+        clientId: "me",
+        steps: ownSteps,
+      });
+      await ctx.db.insert("deltas", {
+        id,
+        version: 3,
+        clientId: "other",
+        steps: stepsJSON(foreign),
+      });
+    });
+
+    expect(await flushPendingSteps(realClient(t), syncApi, id, state)).toBe(
+      "flushed",
+    );
+
+    const server = await t.query(api.lib.getSteps, { id, version: 1 });
+    expect(server.version).toBe(3);
+    expect(server.clientIds).toEqual(["me", "other"]);
+  });
+
+  test("sends steps in batches, confirming only what each round submitted", async () => {
+    const t = convexTest(componentSchema, modules);
+    const id = crypto.randomUUID();
+    await seedSnapshot(t, id);
+    // More steps than MAX_STEPS_SYNC (1000), so the flush needs two rounds.
+    let state = stateAt(1, "me");
+    for (let i = 0; i < 1001; i++) {
+      state = typeText(state, "a");
+    }
+    expect(collab.sendableSteps(state)!.steps.length).toBe(1001);
+
+    expect(await flushPendingSteps(realClient(t), syncApi, id, state)).toBe(
+      "flushed",
+    );
+
+    await t.run(async (ctx) => {
+      const deltas = await ctx.db
+        .query("deltas")
+        .withIndex("id_version", (q) => q.eq("id", id))
+        .collect();
+      expect(deltas.map((d) => d.steps.length)).toEqual([1000, 1]);
+      expect(deltas[deltas.length - 1].version).toBe(1002);
+    });
+  });
+
+  test("does nothing when there is nothing unconfirmed", async () => {
+    const t = convexTest(componentSchema, modules);
+    const id = crypto.randomUUID();
+    await seedSnapshot(t, id);
+
+    expect(
+      await flushPendingSteps(realClient(t), syncApi, id, stateAt(1, "me")),
+    ).toBe("flushed");
+
+    const server = await t.query(api.lib.getSteps, { id, version: 1 });
+    expect(server.steps).toEqual([]);
+  });
+
+  test("gives up (rather than throwing) when the submit fails", async () => {
+    const state = typeText(stateAt(1, "me"), "hello");
+    const convex = fakeClient(() => Promise.reject(new Error("network down")));
+
+    expect(await flushPendingSteps(convex, syncApi, "doc", state)).toBe(
+      "gave-up",
+    );
+  });
+
+  test("gives up instead of rebasing forever", async () => {
+    const state = typeText(stateAt(1, "me"), "hello");
+    // A server that never accepts our steps: every submit needs another rebase.
+    const foreignStep = stepsJSON(typeText(stateAt(1, "other"), "x"))[0];
+    let calls = 0;
+    const convex = fakeClient(() => {
+      calls++;
+      return Promise.resolve({
+        status: "needs-rebase",
+        steps: [foreignStep],
+        clientIds: ["other"],
+      } as const);
+    });
+
+    expect(await flushPendingSteps(convex, syncApi, "doc", state)).toBe(
+      "gave-up",
+    );
+    expect(calls).toBeGreaterThan(1);
+    expect(calls).toBeLessThan(100);
+  });
+
+  test("rejects when a step can't be applied, so onDestroy can report it", async () => {
+    const t = convexTest(componentSchema, modules);
+    const id = crypto.randomUUID();
+    await seedSnapshot(t, id);
+    // A delta the local schema can't make sense of, so the rebase throws
+    // rather than the mutation. onDestroy routes this to onSyncError.
+    await t.run(async (ctx) => {
+      await ctx.db.insert("deltas", {
+        id,
+        version: 2,
+        clientId: "other",
+        steps: ["{}"],
+      });
+    });
+    const state = typeText(stateAt(1, "me"), "hello");
+
+    await expect(
+      flushPendingSteps(realClient(t), syncApi, id, state),
+    ).rejects.toThrow();
+  });
+});
+
+/**
+ * Call the extension's onDestroy the way tiptap does, with a stand-in for the
+ * editor: onDestroy only reads `editor.state`, and that state is a real one.
+ * (A real Editor needs a DOM, which this test environment doesn't have.)
+ */
+function destroy(extension: AnyExtension, state: EditorState) {
+  const onDestroy = (
+    extension.config as {
+      onDestroy?: (this: { editor: Editor }) => void;
+    }
+  ).onDestroy;
+  onDestroy!.call({ editor: { state } as Editor });
+}
+
+function extensionWith(
+  convex: ConvexReactClient,
+  onSyncError: (error: Error) => void,
+) {
+  return syncExtension(
+    convex,
+    "doc",
+    syncApi,
+    { initialContent: { type: "doc", content: [] }, initialVersion: 1 },
+    { onSyncError },
+  );
+}
+
+describe("onDestroy error reporting", () => {
+  test("reports a flush that gave up", async () => {
+    const errors: Error[] = [];
+    const convex = fakeClient(() => Promise.reject(new Error("network down")));
+
+    destroy(
+      extensionWith(convex, (error) => errors.push(error)),
+      typeText(stateAt(1, "me"), "hello"),
+    );
+
+    await vi.waitFor(() => expect(errors).toHaveLength(1));
+    expect(errors[0].message).toContain(
+      "Unsynced steps could not be flushed after destroy",
+    );
+  });
+
+  test("reports a flush that threw rather than becoming an unhandled rejection", async () => {
+    const errors: Error[] = [];
+    // A step the flush can't apply: this rejects the flush promise instead of
+    // resolving to "gave-up", so it only reaches onSyncError if onDestroy
+    // attached a rejection handler.
+    const convex = fakeClient(() =>
+      Promise.resolve({
+        status: "needs-rebase",
+        steps: ["{}"],
+        clientIds: ["other"],
+      } as const),
+    );
+
+    destroy(
+      extensionWith(convex, (error) => errors.push(error)),
+      typeText(stateAt(1, "me"), "hello"),
+    );
+
+    await vi.waitFor(() => expect(errors).toHaveLength(1));
+    expect(errors[0].message).not.toContain("could not be flushed");
+  });
+
+  test("stays quiet when there is nothing to flush", async () => {
+    const errors: Error[] = [];
+    const convex = fakeClient(() => Promise.reject(new Error("never called")));
+
+    destroy(
+      extensionWith(convex, (error) => errors.push(error)),
+      stateAt(1, "me"),
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(errors).toEqual([]);
+  });
+});

--- a/src/tiptap/index.ts
+++ b/src/tiptap/index.ts
@@ -26,6 +26,17 @@ const SNAPSHOT_DEBOUNCE_MS = 1000;
 const MAX_FLUSH_REBASES = 20;
 
 export type UseSyncOptions = {
+  /**
+   * Called when syncing fails. Strongly recommended: some sync work happens
+   * with no caller to propagate to (the debounced snapshot submit, and the
+   * flush of unconfirmed steps when the editor is destroyed), so without this
+   * handler those failures surface as unhandled promise rejections.
+   *
+   * Errors are informational — the extension keeps syncing and will retry on
+   * the next local change or server update. The one error that indicates data
+   * loss is "Unsynced steps could not be flushed after destroy": local steps
+   * that never reached the server before the editor went away.
+   */
   onSyncError?: (error: Error) => void;
   snapshotDebounceMs?: number;
   debug?: boolean;
@@ -124,6 +135,18 @@ export function syncExtension(
   opts?: UseSyncOptions,
 ): AnyExtension {
   const log: typeof console.log = opts?.debug ? console.debug : () => {};
+  // Errors from fire-and-forget paths (the debounced snapshot submit, the
+  // destroy-time flush) have no caller to propagate to. Route them to
+  // `onSyncError` when it's provided; otherwise rethrow, matching `trySync`
+  // so that a missing handler is loud rather than silently dropping the
+  // failure. See the "Handling sync errors" section of the README.
+  const reportError = (error: Error) => {
+    if (opts?.onSyncError) {
+      opts.onSyncError(error);
+    } else {
+      throw error;
+    }
+  };
   let snapshotTimer: NodeJS.Timeout | undefined;
   const trySubmitSnapshot = (version: number, content: string) => {
     if (snapshotTimer) {
@@ -133,7 +156,7 @@ export function syncExtension(
       snapshotTimer = undefined;
       void convex
         .mutation(syncApi.submitSnapshot, { id, version, content })
-        .catch(opts?.onSyncError);
+        .catch(reportError);
     }, opts?.snapshotDebounceMs ?? SNAPSHOT_DEBOUNCE_MS);
   };
 
@@ -218,9 +241,7 @@ export function syncExtension(
         pending = undefined;
         // Retry every still-subscribed editor that queued — the closure's
         // `editor` may be the destroyed StrictMode twin.
-        const targets = [...pendingEditors].filter((e) =>
-          subscriptions.has(e),
-        );
+        const targets = [...pendingEditors].filter((e) => subscriptions.has(e));
         pendingEditors.clear();
         if (targets.length > 0) {
           Promise.all(targets.map((e) => trySync(e))).then(
@@ -264,11 +285,16 @@ export function syncExtension(
         void flushPendingSteps(convex, syncApi, id, state, opts?.debug).then(
           (outcome) => {
             if (outcome === "gave-up") {
-              opts?.onSyncError?.(
+              reportError(
                 new Error("Unsynced steps could not be flushed after destroy"),
               );
             }
           },
+          // Only the mutation is caught inside flushPendingSteps; a step that
+          // fails to apply against the captured state (or a malformed step
+          // from the server) rejects here. Without this handler that would be
+          // an unhandled rejection at teardown instead of a reported error.
+          reportError,
         );
       }
     },
@@ -290,7 +316,11 @@ export function syncExtension(
       subscriptions.set(editor, { watch, unsubscribe });
       void trySync(editor);
       // Install beforeunload handler if not explicitly disabled.
-      if (opts?.warnOnUnsyncedClose !== false && typeof window !== "undefined" && typeof window.addEventListener === "function") {
+      if (
+        opts?.warnOnUnsyncedClose !== false &&
+        typeof window !== "undefined" &&
+        typeof window.addEventListener === "function"
+      ) {
         const beforeUnloadHandler = (e: BeforeUnloadEvent) => {
           if (collab.sendableSteps(editor.state)) {
             e.preventDefault();
@@ -452,8 +482,13 @@ function receiveSteps(
  * steps rebase ours. Best-effort: a network/permission failure means the
  * steps are lost — the same outcome as before this existed — but the
  * common case (in-app navigation mid round-trip) now persists.
+ *
+ * Rejects if a step fails to apply against the captured state; the caller in
+ * `onDestroy` routes that to `onSyncError`.
+ *
+ * @internal Exported for tests. Not part of the supported API.
  */
-async function flushPendingSteps(
+export async function flushPendingSteps(
   convex: ConvexReactClient,
   syncApi: SyncApi,
   id: string,

--- a/src/tiptap/index.ts
+++ b/src/tiptap/index.ts
@@ -12,6 +12,7 @@ import {
   Extension,
   type JSONContent,
 } from "@tiptap/core";
+import type { EditorState } from "@tiptap/pm/state";
 import * as collab from "prosemirror-collab";
 import { Step } from "@tiptap/pm/transform";
 import { useCallback, useMemo, useRef } from "react";
@@ -20,6 +21,9 @@ import type { SyncApi } from "../client/index.js";
 // How many steps we will attempt to sync in one request.
 const MAX_STEPS_SYNC = 1000;
 const SNAPSHOT_DEBOUNCE_MS = 1000;
+// How many consecutive rebase rounds flushPendingSteps tolerates before
+// giving up (successful submissions don't count — they always make progress).
+const MAX_FLUSH_REBASES = 20;
 
 export type UseSyncOptions = {
   onSyncError?: (error: Error) => void;
@@ -126,6 +130,7 @@ export function syncExtension(
       clearTimeout(snapshotTimer);
     }
     snapshotTimer = setTimeout(() => {
+      snapshotTimer = undefined;
       void convex
         .mutation(syncApi.submitSnapshot, { id, version, content })
         .catch(opts?.onSyncError);
@@ -136,10 +141,29 @@ export function syncExtension(
   let pending:
     | { resolve: () => void; reject: () => void; promise: Promise<void> }
     | undefined;
-  let watch: Watch<number | null> | undefined;
+  // Which editors queued behind an active sync — the retry in `finally`
+  // must serve every one of them, not whichever editor's closure happened
+  // to finish (under React StrictMode two live editors briefly share this
+  // extension instance).
+  const pendingEditors = new Set<Editor>();
+
+  // Per-editor subscription state. Storing `watch`/`unsubscribe` in shared
+  // closure variables breaks under React 18 StrictMode: the double-mount
+  // destroys the FIRST editor after the second one was created (TipTap
+  // defers destruction by a tick), so the shared `unsubscribe` — already
+  // reassigned by the second onCreate — tears down the LIVE editor's
+  // subscription and passive step delivery stalls for the whole session.
+  const subscriptions = new Map<
+    Editor,
+    { watch: Watch<number | null>; unsubscribe: () => void }
+  >();
+  const beforeUnloadHandlers = new Map<
+    Editor,
+    (e: BeforeUnloadEvent) => void
+  >();
 
   async function trySync(editor: Editor) {
-    const serverVersion = watch?.localQueryResult();
+    const serverVersion = subscriptions.get(editor)?.watch.localQueryResult();
     if (serverVersion === undefined) {
       return;
     }
@@ -148,6 +172,7 @@ export function syncExtension(
       snapshotTimer = undefined;
     }
     if (active) {
+      pendingEditors.add(editor);
       if (!pending) {
         let resolve = () => {};
         let reject = () => {};
@@ -191,22 +216,60 @@ export function syncExtension(
       if (pending) {
         const { resolve, reject } = pending;
         pending = undefined;
-        trySync(editor).then(resolve, reject);
+        // Retry every still-subscribed editor that queued — the closure's
+        // `editor` may be the destroyed StrictMode twin.
+        const targets = [...pendingEditors].filter((e) =>
+          subscriptions.has(e),
+        );
+        pendingEditors.clear();
+        if (targets.length > 0) {
+          Promise.all(targets.map((e) => trySync(e))).then(
+            () => resolve(),
+            reject,
+          );
+        } else {
+          resolve();
+        }
       }
     }
   }
-
-  let unsubscribe: (() => void) | undefined;
-  let beforeUnloadHandler: ((e: BeforeUnloadEvent) => void) | undefined;
 
   return Extension.create({
     name: "convex-sync",
     onDestroy() {
       log("destroying");
-      unsubscribe?.();
+      const editor = this.editor;
+      subscriptions.get(editor)?.unsubscribe();
+      subscriptions.delete(editor);
+      pendingEditors.delete(editor);
+      const beforeUnloadHandler = beforeUnloadHandlers.get(editor);
       if (beforeUnloadHandler) {
         window.removeEventListener?.("beforeunload", beforeUnloadHandler);
-        beforeUnloadHandler = undefined;
+        beforeUnloadHandlers.delete(editor);
+      }
+      // Only clear the debounced snapshot once the LAST editor is gone —
+      // under StrictMode the deferred first destroy runs while the second
+      // editor is live and may own the pending snapshot.
+      if (subscriptions.size === 0 && snapshotTimer) {
+        clearTimeout(snapshotTimer);
+        snapshotTimer = undefined;
+      }
+      // Local steps still awaiting confirmation must not die with the view
+      // (steps ARE the persistence model; `warnOnUnsyncedClose` only covers
+      // tab close, not in-app unmounts). The state object is immutable and
+      // outlives the view — 'destroy' fires before the view is torn down,
+      // so this read is safe.
+      const state = editor.state;
+      if (collab.sendableSteps(state)) {
+        void flushPendingSteps(convex, syncApi, id, state, opts?.debug).then(
+          (outcome) => {
+            if (outcome === "gave-up") {
+              opts?.onSyncError?.(
+                new Error("Unsynced steps could not be flushed after destroy"),
+              );
+            }
+          },
+        );
       }
     },
     onCreate() {
@@ -219,21 +282,23 @@ export function syncExtension(
         }
         this.editor.view.dispatch(tr);
       }
-      watch = convex.watchQuery(syncApi.latestVersion, { id });
-      unsubscribe = watch.onUpdate(() => {
-        void trySync(this.editor);
+      const editor = this.editor;
+      const watch = convex.watchQuery(syncApi.latestVersion, { id });
+      const unsubscribe = watch.onUpdate(() => {
+        void trySync(editor);
       });
-      void trySync(this.editor);
+      subscriptions.set(editor, { watch, unsubscribe });
+      void trySync(editor);
       // Install beforeunload handler if not explicitly disabled.
       if (opts?.warnOnUnsyncedClose !== false && typeof window !== "undefined" && typeof window.addEventListener === "function") {
-        const editor = this.editor;
-        beforeUnloadHandler = (e: BeforeUnloadEvent) => {
+        const beforeUnloadHandler = (e: BeforeUnloadEvent) => {
           if (collab.sendableSteps(editor.state)) {
             e.preventDefault();
             // Required for older browsers.
             e.returnValue = "";
           }
         };
+        beforeUnloadHandlers.set(editor, beforeUnloadHandler);
         window.addEventListener("beforeunload", beforeUnloadHandler);
       }
     },
@@ -291,14 +356,35 @@ async function doSync(
       id,
       version,
     });
-    receiveSteps(
-      editor,
-      steps.steps.map((step) => Step.fromJSON(editor.schema, JSON.parse(step))),
-      steps.clientIds,
-    );
+    if (editor.isDestroyed) return false;
+    // The local version may have advanced while the fetch was in flight
+    // (another trySync interleave, or any other applier) — applying the
+    // full batch would then re-apply an already-applied prefix, duplicating
+    // content and inflating the collab version past the server's. The next
+    // submitSteps would insert a delta with a version GAP, permanently
+    // wedging the document for every client. Apply only what is still
+    // ahead of us.
+    const skip = collab.getVersion(editor.state) - version;
+    if (skip >= 0 && skip < steps.steps.length) {
+      receiveSteps(
+        editor,
+        steps.steps
+          .slice(skip)
+          .map((step) => Step.fromJSON(editor.schema, JSON.parse(step))),
+        steps.clientIds.slice(skip),
+      );
+    }
   }
   let anyChanges = false;
   while (true) {
+    // A destroy mid-round-trip freezes editor.state (dispatching to a
+    // destroyed view is a silent no-op), so the confirm/rebase applies
+    // below stop landing and this loop would re-submit the same stale
+    // batch forever. onDestroy's flushPendingSteps owns the remaining
+    // steps from here. Return false: the frozen state still shows
+    // sendable steps, and reporting a successful sync would trip the
+    // "Synced but still have sendable steps" invariant in trySync.
+    if (editor.isDestroyed) return false;
     const sendable = collab.sendableSteps(editor.state);
     if (!sendable) {
       break;
@@ -355,6 +441,69 @@ function receiveSteps(
       mapSelectionBackward: true,
     }),
   );
+}
+
+/**
+ * Submit a destroyed editor's unconfirmed local steps — the doSync send
+ * loop run headlessly against the captured EditorState (which is immutable
+ * and outlives the view). prosemirror-collab's receiveTransaction does the
+ * heavy lifting exactly as it would live: own-clientID steps confirm (the
+ * pre-destroy in-flight submit may turn out to have landed them), foreign
+ * steps rebase ours. Best-effort: a network/permission failure means the
+ * steps are lost — the same outcome as before this existed — but the
+ * common case (in-app navigation mid round-trip) now persists.
+ */
+async function flushPendingSteps(
+  convex: ConvexReactClient,
+  syncApi: SyncApi,
+  id: string,
+  state: EditorState,
+  debug?: boolean,
+): Promise<"flushed" | "gave-up"> {
+  const log: typeof console.log = debug ? console.debug : () => {};
+  let rebases = 0;
+  while (rebases < MAX_FLUSH_REBASES) {
+    const sendable = collab.sendableSteps(state);
+    if (!sendable) return "flushed";
+    // Confirm only what is actually sent this round — the remainder past
+    // MAX_STEPS_SYNC drains on the next iteration.
+    const toSend = sendable.steps.slice(0, MAX_STEPS_SYNC);
+    let result;
+    try {
+      result = await convex.mutation(syncApi.submitSteps, {
+        id,
+        version: sendable.version,
+        clientId: sendable.clientID,
+        steps: toSend.map((step) => JSON.stringify(step.toJSON())),
+      });
+    } catch (error) {
+      log("Flush after destroy failed", { id, error });
+      return "gave-up";
+    }
+    if (result.status === "synced") {
+      state = state.apply(
+        collab.receiveTransaction(
+          state,
+          toSend,
+          toSend.map(() => sendable.clientID),
+          { mapSelectionBackward: true },
+        ),
+      );
+    } else {
+      rebases++;
+      state = state.apply(
+        collab.receiveTransaction(
+          state,
+          result.steps.map((step) =>
+            Step.fromJSON(state.schema, JSON.parse(step)),
+          ),
+          result.clientIds,
+          { mapSelectionBackward: true },
+        ),
+      );
+    }
+  }
+  return "gave-up";
 }
 
 type InitialState = {


### PR DESCRIPTION
fix(tiptap): three lifecycle bugs — StrictMode subscription teardown, post-await version re-check, flush pending steps on destroy

Fixes #269.

1. Per-editor subscription/beforeunload maps: shared closure variables
   meant React 18 StrictMode's deferred first destroy (create1 -> create2
   -> destroy1) unsubscribed the LIVE editor's latestVersion watch,
   permanently stalling passive step delivery. Queued trySync waiters are
   also tracked per editor so the finally-retry serves the surviving one.

2. doSync's catch-up fetch re-checks the collab version after the await
   and applies only the still-unapplied suffix — previously an interleaved
   applier during the fetch caused a double-apply, inflating the local
   version past the server and permanently wedging the document's step log
   with a version gap on the next submit. The send loop also guards
   editor.isDestroyed per iteration (dispatch on a destroyed view is a
   silent no-op, so the loop otherwise re-submits the same stale batch
   forever).

3. onDestroy flushes unconfirmed local steps by running the send/rebase
   loop headlessly against the captured (immutable) EditorState — in-app
   unmounts mid round-trip previously dropped them silently
   (warnOnUnsyncedClose only covers tab close). The debounced snapshot
   timer is cleared once the last editor unsubscribes.

Validated in production use: passive two-tab convergence under StrictMode,
and type-then-navigate losing nothing.

test(tiptap): cover the destroy-time flush, and report its errors

Follow-up to the previous commit:

- onDestroy attaches a rejection handler to flushPendingSteps. Only the
  mutation is caught inside the flush, so a step that fails to apply
  against the captured state was an unhandled rejection at teardown
  rather than a reported error. Both destroy-time failure paths (and the
  debounced snapshot submit) now go through one reportError helper: call
  onSyncError when provided, otherwise rethrow, matching trySync so a
  missing handler is loud rather than silent.

- Tests for flushPendingSteps against the real component: a clean flush,
  rebasing over steps that landed first, confirming steps whose in-flight
  submit turned out to have landed (without duplicating them), batching
  past MAX_STEPS_SYNC, giving up on a failed submit, and terminating
  instead of rebasing forever. Plus onDestroy's error reporting, driven
  through the extension's own handler.

- A component test pinning the failure mode that motivates the version
  re-check: a gap in the delta log makes getSteps throw for every client.

- Document onSyncError in the README and on UseSyncOptions, along with
  what the destroy-time flush does and doesn't guarantee.